### PR TITLE
set max length to 500 in job title

### DIFF
--- a/aspnet-core/src/toyiyo.todo.Web.Mvc/Views/Jobs/Index.cshtml
+++ b/aspnet-core/src/toyiyo.todo.Web.Mvc/Views/Jobs/Index.cshtml
@@ -36,7 +36,7 @@
                             <div class="col-md-12">
                                     <form name="JobCreateForm" id="JobCreateForm" role="form" class="row bg-white rounded shadow-sm p-2 add-todo-wrapper align-items-center justify-content-center">
                                         <div class="col">
-                                            <input class="form-control form-control-lg border-0 add-todo-input bg-transparent rounded" type="text" id="jobtitle" name="title" placeholder=@L("AddNew") />
+                                            <input class="form-control form-control-lg border-0 add-todo-input bg-transparent rounded" type="text" id="jobtitle" name="title" required maxlength="500" minlength="2" placeholder=@L("AddNew") />
                                         </div>
                                         <div class="col-auto m-0 px-2 d-flex align-items-center">
                                             <label class="text-secondary my-2 p-0 px-1 view-opt-label due-date-label d-none">Due date not set</label>

--- a/aspnet-core/src/toyiyo.todo.Web.Mvc/Views/Jobs/_EditModal.cshtml
+++ b/aspnet-core/src/toyiyo.todo.Web.Mvc/Views/Jobs/_EditModal.cshtml
@@ -11,7 +11,7 @@
         <div class="form-group row required">
             <label class="col-md-3 col-form-label" for="title">@L("JobTitle")</label>
             <div class="col-md-9">
-                <input id="title" class="form-control" type="text" name="title" value="@Model.Title" required maxlength="32" minlength="2">
+                <input id="title" class="form-control" type="text" name="title" value="@Model.Title" required maxlength="500" minlength="2">
             </div>
         </div>
     </div>


### PR DESCRIPTION
closes #17 

Increasing the job title `required maxlength` attribute to 500 so it matches our backend limits