### PR TITLE
set total count to items prior to pagination/ordering

### DIFF
--- a/aspnet-core/src/toyiyo.todo.Application/Jobs/JobAppService.cs
+++ b/aspnet-core/src/toyiyo.todo.Application/Jobs/JobAppService.cs
@@ -38,7 +38,8 @@ namespace toyiyo.todo.Jobs
         public async Task<PagedResultDto<JobDto>> GetAll(GetAllJobsInput input)
         {
             var jobs = await _jobManager.GetAll(input);
-            return new PagedResultDto<JobDto>(jobs.Count, ObjectMapper.Map<List<JobDto>>(jobs));
+            var jobsTotalCount = await _jobManager.GetAllCount(input);
+            return new PagedResultDto<JobDto>(jobsTotalCount, ObjectMapper.Map<List<JobDto>>(jobs));
         }
 
         public async Task<JobDto> SetDescription(JobSetDescriptionInputDto jobSetDescriptionInputDto)

--- a/aspnet-core/src/toyiyo.todo.Application/Projects/ProjectAppService.cs
+++ b/aspnet-core/src/toyiyo.todo.Application/Projects/ProjectAppService.cs
@@ -28,7 +28,8 @@ namespace toyiyo.todo.Projects {
         /// <summary> Gets all Projects. Keyword filters by Title</summary>
         public async Task<PagedResultDto<ProjectDto>> GetAll(GetAllProjectsInput input) {
             var projects = await _projectManager.GetAll(input);
-            return new PagedResultDto<ProjectDto>(projects.Count, ObjectMapper.Map<List<ProjectDto>>(projects));
+            var projectsTotalCount = await _projectManager.GetAllCount(input);
+            return new PagedResultDto<ProjectDto>(projectsTotalCount, ObjectMapper.Map<List<ProjectDto>>(projects));
         }
 
         /// <summary> Sets the project's title </summary>

--- a/aspnet-core/src/toyiyo.todo.Core/Jobs/IJobManager.cs
+++ b/aspnet-core/src/toyiyo.todo.Core/Jobs/IJobManager.cs
@@ -9,6 +9,8 @@ namespace toyiyo.todo.Jobs
         Task<Job> Create(Job inputJob);
         Task<Job> Get(Guid id);
         Task<List<Job>> GetAll(GetAllJobsInput input);
+
+        Task<int> GetAllCount(GetAllJobsInput input);
         Task<Job> Update(Job inputJob);
     }
 }

--- a/aspnet-core/src/toyiyo.todo.Core/Jobs/JobsManager.cs
+++ b/aspnet-core/src/toyiyo.todo.Core/Jobs/JobsManager.cs
@@ -36,8 +36,8 @@ namespace toyiyo.todo.Jobs
             .Include(p => p.Assignee)
             .Include(p => p.Owner)
             .OrderBy<Job>(input?.Sorting ?? "CreationTime DESC")
-            .Skip(input.SkipCount)
-            .Take(input.MaxResultCount)
+            .Skip(input?.SkipCount ?? 0)
+            .Take(input?.MaxResultCount ?? int.MaxValue)
             .ToListAsync();
         }
 

--- a/aspnet-core/src/toyiyo.todo.Core/Projects/IProjectManager.cs
+++ b/aspnet-core/src/toyiyo.todo.Core/Projects/IProjectManager.cs
@@ -9,6 +9,8 @@ namespace toyiyo.todo.Projects
         Task<Project> Create(Project inputProject);
         Task<Project> Get(Guid id);
         Task<List<Project>> GetAll(GetAllProjectsInput input);
+
+        Task<int> GetAllCount(GetAllProjectsInput input);
         Task<Project> Update(Project inputProject);
     }
 }

--- a/aspnet-core/src/toyiyo.todo.Core/Projects/ProjectManager.cs
+++ b/aspnet-core/src/toyiyo.todo.Core/Projects/ProjectManager.cs
@@ -34,8 +34,8 @@ namespace toyiyo.todo.Projects
             //todo: figure out how to ignore case when searching for title in postgresql
             return await GetAllProjectsQueryable(input)
             .OrderBy<Project>(input?.Sorting ?? "CreationTime DESC")
-            .Skip(input.SkipCount)
-            .Take(input.MaxResultCount)
+            .Skip(input?.SkipCount ?? 0)
+            .Take(input?.MaxResultCount ?? int.MaxValue)
             .ToListAsync();
         }
 

--- a/aspnet-core/src/toyiyo.todo.Core/Projects/ProjectManager.cs
+++ b/aspnet-core/src/toyiyo.todo.Core/Projects/ProjectManager.cs
@@ -32,12 +32,24 @@ namespace toyiyo.todo.Projects
         {
             //repository methods already filter by tenant, we can check other attributes by adding "or" "||" to the whereif clause
             //todo: figure out how to ignore case when searching for title in postgresql
-            return await _projectRepository.GetAll()
-            .WhereIf(!input.keyword.IsNullOrWhiteSpace(), p => p.Title.ToUpper().Contains(input.keyword.ToUpper()))
+            return await GetAllProjectsQueryable(input)
             .OrderBy<Project>(input?.Sorting ?? "CreationTime DESC")
             .Skip(input.SkipCount)
             .Take(input.MaxResultCount)
             .ToListAsync();
+        }
+
+        [UnitOfWork]
+        public async Task<int> GetAllCount(GetAllProjectsInput input)
+        {
+            return await GetAllProjectsQueryable(input).CountAsync();
+        }
+
+        private IQueryable<Project> GetAllProjectsQueryable(GetAllProjectsInput input)
+        {
+            //repository methods already filter by tenant, we can check other attributes by adding "or" "||" to the whereif clause
+            return _projectRepository.GetAll()
+            .WhereIf(!input.keyword.IsNullOrWhiteSpace(), p => p.Title.ToUpper().Contains(input.keyword.ToUpper()));
         }
 
         public async Task<Project> Create(Project inputProject)

--- a/aspnet-core/src/toyiyo.todo.Web.Mvc/wwwroot/view-resources/Views/Jobs/Index.js
+++ b/aspnet-core/src/toyiyo.todo.Web.Mvc/wwwroot/view-resources/Views/Jobs/Index.js
@@ -26,7 +26,7 @@
     var _$jobsTable = _$table.DataTable({
         paging: true,
         serverSide: true,
-        lengthMenu: [ [25, 50, 2147483647], [25, 50, "All"] ],
+        //lengthMenu: [ [25, 50, 2147483647], [25, 50, "All"] ],
         listAction: {
             ajaxFunction: abp.services.app.job.getAll,
             inputFilter: function () {
@@ -39,7 +39,7 @@
             dataFilter: function (data) {
                 var json = jQuery.parseJSON(data);
                 json.recordsTotal = json.TotalCount;
-                json.recordsFiltered = json.TotalCount;
+                json.recordsFiltered = json.Items.length;
                 json.data = json.list;
                 return JSON.stringify(json);
             }

--- a/aspnet-core/src/toyiyo.todo.Web.Mvc/wwwroot/view-resources/Views/Projects/Index.js
+++ b/aspnet-core/src/toyiyo.todo.Web.Mvc/wwwroot/view-resources/Views/Projects/Index.js
@@ -24,8 +24,8 @@
             },
             dataFilter : function(data){
                 var json = jQuery.parseJSON( data );
-                json.recordsTotal = json.TotalCount;
-                json.recordsFiltered = json.TotalCount;
+                json.recordsTotal = json.totalCount;
+                json.recordsFiltered = json.items.length;
                 json.data = json.list;
                 return JSON.stringify( json );
             }

--- a/aspnet-core/test/toyiyo.todo.Tests/Jobs/JobAppServiceTests.cs
+++ b/aspnet-core/test/toyiyo.todo.Tests/Jobs/JobAppServiceTests.cs
@@ -139,6 +139,27 @@ namespace toyiyo.todo.Tests.Jobs
             jobs.Items.First().Title.ShouldBe("A");
             jobs.Items[1].Title.ShouldBe("Z");
         }
+
+        [Fact]
+        public async Task GetAllJobs_Paging()
+        {
+            // Arrange
+            var currentUser = await GetCurrentUserAsync();
+            var currentTenant = await GetCurrentTenantAsync();
+            var project = await _projectAppService.Create(new CreateProjectInputDto() { Title = "test" });
+            var job = await _jobAppServices.Create(new JobCreateInputDto() { ProjectId = project.Id, Title = "test job", Description = "test job" });
+            var job2 = await _jobAppServices.Create(new JobCreateInputDto() { ProjectId = project.Id, Title = "test job2", Description = "test job2" });
+
+            // Act
+            var jobs = await _jobAppServices.GetAll(new GetAllJobsInput() { ProjectId = project.Id, MaxResultCount = 1 });
+
+            // Assert items count is 1 and total count is 2 and is sorted by creation date desc
+            jobs.ShouldNotBeNull();
+            jobs.Items.Count.ShouldBe(1);
+            jobs.TotalCount.ShouldBe(2);
+            jobs.Items.First().Title.ShouldBe("test job2");
+        }
+
         [Fact]
         public async Task SetTitle_ReturnsJob()
         {

--- a/aspnet-core/test/toyiyo.todo.Tests/Jobs/JobAppServiceTests.cs
+++ b/aspnet-core/test/toyiyo.todo.Tests/Jobs/JobAppServiceTests.cs
@@ -149,6 +149,7 @@ namespace toyiyo.todo.Tests.Jobs
             var project = await _projectAppService.Create(new CreateProjectInputDto() { Title = "test" });
             var job = await _jobAppServices.Create(new JobCreateInputDto() { ProjectId = project.Id, Title = "test job", Description = "test job" });
             var job2 = await _jobAppServices.Create(new JobCreateInputDto() { ProjectId = project.Id, Title = "test job2", Description = "test job2" });
+            var job3 = await _jobAppServices.Create(new JobCreateInputDto() { ProjectId = project.Id, Title = "test job3", Description = "test job3" });
 
             // Act
             var jobs = await _jobAppServices.GetAll(new GetAllJobsInput() { ProjectId = project.Id, MaxResultCount = 1 });
@@ -156,8 +157,8 @@ namespace toyiyo.todo.Tests.Jobs
             // Assert items count is 1 and total count is 2 and is sorted by creation date desc
             jobs.ShouldNotBeNull();
             jobs.Items.Count.ShouldBe(1);
-            jobs.TotalCount.ShouldBe(2);
-            jobs.Items.First().Title.ShouldBe("test job2");
+            jobs.TotalCount.ShouldBe(3);
+            jobs.Items[0].Title.ShouldBe("test job3");
         }
 
         [Fact]

--- a/aspnet-core/test/toyiyo.todo.Tests/Projects/ProjectAppServiceTests.cs
+++ b/aspnet-core/test/toyiyo.todo.Tests/Projects/ProjectAppServiceTests.cs
@@ -99,5 +99,26 @@ namespace toyiyo.todo.Tests.Projects
             result.ShouldNotBeNull();
             result.Title.ShouldBe("test2");
         }
+
+        [Fact]
+        public async Task GetAllProjects_Paging()
+        {
+                    // Arrange
+            var currentUser = await GetCurrentUserAsync();
+            var currentTenant = await GetCurrentTenantAsync();
+            await _projectAppService.Create(new CreateProjectInputDto() { Title = "test" });
+            await _projectAppService.Create(new CreateProjectInputDto() { Title = "test2" });
+            await _projectAppService.Create(new CreateProjectInputDto() { Title = "test3" });
+
+            // Act
+            var result = await _projectAppService.GetAll(new GetAllProjectsInput(){ MaxResultCount = 1});
+
+            // Assert
+            result.ShouldNotBeNull();
+            result.Items.Count.ShouldBe(1);
+            result.TotalCount.ShouldBe(3);
+            result.Items[0].Title.ShouldBe("test3");  
+
+        }
     }
 }


### PR DESCRIPTION
closes #11

sets totalCount in response to be the total count of filtered results.
the items returned are further filtered by `skip` and `take` for page number and page size respectively