### PR TITLE
Access to change password via dedicated permission

### DIFF
--- a/aspnet-core/src/toyiyo.todo.Application/Users/UserAppService.cs
+++ b/aspnet-core/src/toyiyo.todo.Application/Users/UserAppService.cs
@@ -25,7 +25,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace toyiyo.todo.Users
 {
-    [AbpAuthorize(PermissionNames.Pages_Users)]
+    [AbpAuthorize]
     public class UserAppService : AsyncCrudAppService<User, UserDto, long, PagedUserResultRequestDto, CreateUserDto, UserDto>, IUserAppService
     {
         private readonly UserManager _userManager;
@@ -52,7 +52,7 @@ namespace toyiyo.todo.Users
             _abpSession = abpSession;
             _logInManager = logInManager;
         }
-
+        [AbpAuthorize(PermissionNames.Pages_Users)]
         public override async Task<UserDto> CreateAsync(CreateUserDto input)
         {
             CheckCreatePermission();
@@ -76,6 +76,7 @@ namespace toyiyo.todo.Users
             return MapToEntityDto(user);
         }
 
+        [AbpAuthorize(PermissionNames.Pages_Users)]
         public override async Task<UserDto> UpdateAsync(UserDto input)
         {
             CheckUpdatePermission();
@@ -94,6 +95,7 @@ namespace toyiyo.todo.Users
             return await GetAsync(input);
         }
 
+        [AbpAuthorize(PermissionNames.Pages_Users)]
         public override async Task DeleteAsync(EntityDto<long> input)
         {
             var user = await _userManager.GetUserByIdAsync(input.Id);
@@ -118,12 +120,14 @@ namespace toyiyo.todo.Users
             });
         }
 
+        [AbpAuthorize(PermissionNames.Pages_Users)]
         public async Task<ListResultDto<RoleDto>> GetRoles()
         {
             var roles = await _roleRepository.GetAllListAsync();
             return new ListResultDto<RoleDto>(ObjectMapper.Map<List<RoleDto>>(roles));
         }
 
+        [AbpAuthorize(PermissionNames.Pages_Users)]
         public async Task ChangeLanguage(ChangeUserLanguageDto input)
         {
             await SettingManager.ChangeSettingForUserAsync(
@@ -187,6 +191,7 @@ namespace toyiyo.todo.Users
             identityResult.CheckErrors(LocalizationManager);
         }
 
+        [AbpAuthorize(PermissionNames.Pages_Users_PasswordChange)]
         public async Task<bool> ChangePassword(ChangePasswordDto input)
         {
             await _userManager.InitializeOptionsAsync(AbpSession.TenantId);
@@ -212,6 +217,7 @@ namespace toyiyo.todo.Users
             return true;
         }
 
+        [AbpAuthorize(PermissionNames.Pages_Users_PasswordChange)]
         public async Task<bool> ResetPassword(ResetPasswordDto input)
         {
             if (_abpSession.UserId == null)

--- a/aspnet-core/src/toyiyo.todo.Core/Authorization/PermissionNames.cs
+++ b/aspnet-core/src/toyiyo.todo.Core/Authorization/PermissionNames.cs
@@ -3,10 +3,9 @@
     public static class PermissionNames
     {
         public const string Pages_Tenants = "Pages.Tenants";
-
         public const string Pages_Users = "Pages.Users";
         public const string Pages_Users_Activation = "Pages.Users.Activation";
-
+        public const string Pages_Users_PasswordChange = "Pages.Users.PasswordChange";
         public const string Pages_Roles = "Pages.Roles";
         public const string Pages_Projects = "Pages.Projects";
         public const string Pages_Jobs = "Pages.Jobs";

--- a/aspnet-core/src/toyiyo.todo.Core/Authorization/todoAuthorizationProvider.cs
+++ b/aspnet-core/src/toyiyo.todo.Core/Authorization/todoAuthorizationProvider.cs
@@ -10,6 +10,7 @@ namespace toyiyo.todo.Authorization
         {
             context.CreatePermission(PermissionNames.Pages_Users, L("Users"));
             context.CreatePermission(PermissionNames.Pages_Users_Activation, L("UsersActivation"));
+            context.CreatePermission(PermissionNames.Pages_Users_PasswordChange, L("UsersPasswordChange"));
             context.CreatePermission(PermissionNames.Pages_Roles, L("Roles"));
             context.CreatePermission(PermissionNames.Pages_Tenants, L("Tenants"), multiTenancySides: MultiTenancySides.Host);
             context.CreatePermission(PermissionNames.Pages_Projects, L("Projects"), multiTenancySides: MultiTenancySides.Tenant);

--- a/aspnet-core/src/toyiyo.todo.Core/Localization/SourceFiles/todo.xml
+++ b/aspnet-core/src/toyiyo.todo.Core/Localization/SourceFiles/todo.xml
@@ -128,6 +128,7 @@
     <text name="ResetPasswordStepOneInfo">1. Enter your administrator password</text>
     <text name="ResetPasswordStepTwoInfo">2. Copy this random password so you can send it to the user</text>
     <text name="UsersActivation">Users activation</text>
+    <text name="UsersPasswordChange">Users Password Change</text>
     <text name="AddNew">Add New</text>
     <text name="Add">Add</text>
   </texts>

--- a/aspnet-core/src/toyiyo.todo.Web.Mvc/Controllers/UsersController.cs
+++ b/aspnet-core/src/toyiyo.todo.Web.Mvc/Controllers/UsersController.cs
@@ -9,7 +9,7 @@ using toyiyo.todo.Web.Models.Users;
 
 namespace toyiyo.todo.Web.Controllers
 {
-    [AbpMvcAuthorize(PermissionNames.Pages_Users)]
+    [AbpMvcAuthorize]
     public class UsersController : todoControllerBase
     {
         private readonly IUserAppService _userAppService;
@@ -18,7 +18,7 @@ namespace toyiyo.todo.Web.Controllers
         {
             _userAppService = userAppService;
         }
-
+        [AbpMvcAuthorize(PermissionNames.Pages_Users)]
         public async Task<ActionResult> Index()
         {
             var roles = (await _userAppService.GetRoles()).Items;
@@ -28,7 +28,7 @@ namespace toyiyo.todo.Web.Controllers
             };
             return View(model);
         }
-
+        [AbpMvcAuthorize(PermissionNames.Pages_Users)]
         public async Task<ActionResult> EditModal(long userId)
         {
             var user = await _userAppService.GetAsync(new EntityDto<long>(userId));
@@ -41,6 +41,7 @@ namespace toyiyo.todo.Web.Controllers
             return PartialView("_EditModal", model);
         }
 
+        [AbpMvcAuthorize(PermissionNames.Pages_Users_PasswordChange)]
         public ActionResult ChangePassword()
         {
             return View();

--- a/aspnet-core/test/toyiyo.todo.Web.Tests/Controllers/UsersController_Tests.cs
+++ b/aspnet-core/test/toyiyo.todo.Web.Tests/Controllers/UsersController_Tests.cs
@@ -1,0 +1,29 @@
+using System.Threading.Tasks;
+using toyiyo.todo.Models.TokenAuth;
+using toyiyo.todo.Web.Controllers;
+using Shouldly;
+using Xunit;
+
+namespace toyiyo.todo.Web.Tests.Controllers
+{
+    public class UsersController_Tests: todoWebTestBase
+    {
+        [Fact]
+        public async Task AccessPasswordPage_AsAdmin_Test()
+        {
+            await AuthenticateAsync(null, new AuthenticateModel
+            {
+                UserNameOrEmailAddress = "admin",
+                Password = "123qwe"
+            });
+
+            //Act
+            var response = await GetResponseAsStringAsync(
+                GetUrl<UsersController>(nameof(UsersController.ChangePassword))
+            );
+
+            //Assert
+            response.ShouldNotBeNullOrEmpty();
+        }
+    }
+}


### PR DESCRIPTION
closes #31 

Segmented the ability to update passwords into it's own permission so that it can be assigned to multiple roles.
Before this change, only users with access to the user management permission (Admins) were allowed to update passwords.  This made it so that individual users could not change their own password