### PR TITLE
Update SubscriptionManager.cs

### DIFF
--- a/aspnet-core/src/toyiyo.todo.Core/Subscriptions/SubscriptionManager.cs
+++ b/aspnet-core/src/toyiyo.todo.Core/Subscriptions/SubscriptionManager.cs
@@ -10,6 +10,7 @@ using toyiyo.todo.Authorization.Users;
 using System.Threading.Tasks;
 using toyiyo.todo.MultiTenancy;
 using Abp.Domain.Uow;
+using System.Configuration;
 
 namespace toyiyo.todo.Core.Subscriptions
 {
@@ -24,8 +25,8 @@ namespace toyiyo.todo.Core.Subscriptions
             _tenantManager = tenantManager;
             _userManager = userManager;
             LocalizationSourceName = todoConsts.LocalizationSourceName;
-            _webhookSecret = Environment.GetEnvironmentVariable("StripeWebhookSecret") ?? throw new InvalidOperationException("StripeWebhookSecret environment variable is not set.");
-            StripeConfiguration.ApiKey = Environment.GetEnvironmentVariable("StripeAPIKeyProduction");
+            _webhookSecret = Environment.GetEnvironmentVariable("StripeWebhookSecret") ?? throw new ConfigurationErrorsException("StripeWebhookSecret environment variable is not set.");
+            StripeConfiguration.ApiKey = Environment.GetEnvironmentVariable("StripeAPIKeyProduction") ?? throw new ConfigurationErrorsException("StripeAPIKeyProduction environment variable is not set.");
         }
 
         public Subscription GetSubscriptionById(string subscriptionId)
@@ -68,7 +69,7 @@ namespace toyiyo.todo.Core.Subscriptions
         public async Task StripeWebhookHandler(string json, string stripeSignatureHeader)
         {
             if (string.IsNullOrEmpty(stripeSignatureHeader)) throw new ArgumentException("stripeSignatureHeader cannot be null or empty", nameof(stripeSignatureHeader));
-            
+
             var stripeEvent = EventUtility.ConstructEvent(
               json,
               stripeSignatureHeader,
@@ -105,7 +106,7 @@ namespace toyiyo.todo.Core.Subscriptions
                     await MatchActiveUsersToSeatsAvailable(tenant, quantity);
                 }
             }
-            Logger.Info($"Processed Stripe event: {stripeEvent.Type}");
+            LogStripeEventProcessing(stripeEvent.Type);
         }
 
         private async Task MatchActiveUsersToSeatsAvailable(Tenant tenant, long quantity)
@@ -148,7 +149,7 @@ namespace toyiyo.todo.Core.Subscriptions
 
             // Fulfill the purchase...
             await FulfillOrderAsync(sessionWithLineItems);
-            Logger.Info($"Processed Stripe event: {stripeEvent.Type}");
+            LogStripeEventProcessing(stripeEvent.Type);
         }
 
         private async Task FulfillOrderAsync(Session sessionWithLineItems)
@@ -166,6 +167,11 @@ namespace toyiyo.todo.Core.Subscriptions
             //Sending the customer a receipt email.
             //Reconciling the line items and quantity purchased by the customer if using line_item.adjustable_quantity. 
             //If the Checkout Session has many line items you can paginate through them with the line_items.
+        }
+
+        private void LogStripeEventProcessing(string eventType)
+        {
+            Logger.Info($"Processed Stripe event: {eventType}");
         }
     }
 }


### PR DESCRIPTION
## **Type**
enhancement, bug_fix


___

## **Description**
- Added a null check to ensure `StripeWebhookSecret` environment variable is set during the `SubscriptionManager` initialization.
- Introduced a validation check for `stripeSignatureHeader` in `StripeWebhookHandler` to prevent processing with null or empty values.
- Implemented logging for successfully processed Stripe events in both `CustomerSubscriptionUpdatedHandler` and `CheckoutSessionCompletedHandler` methods to improve monitoring and debugging capabilities.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SubscriptionManager.cs</strong><dd><code>Enhance Stripe Integration with Validation and Logging</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
aspnet-core/src/toyiyo.todo.Core/Subscriptions/SubscriptionManager.cs

<li>Added null check for <code>StripeWebhookSecret</code> environment variable during <br>initialization.<br> <li> Added validation for <code>stripeSignatureHeader</code> parameter to be non-null or <br>empty in <code>StripeWebhookHandler</code> method.<br> <li> Added logging for processed Stripe events in <br><code>CustomerSubscriptionUpdatedHandler</code> and <code>CheckoutSessionCompletedHandler</code> <br>methods.<br>


</details>
    

  </td>
  <td><a href="https://github.com/toyiyo/todo/pull/82/files#diff-d8d773aa6b807d57e6f0c42696b47d4c8ba54b7b94891decd795942681aa100b">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced security and validation for Stripe webhook handling.
	- Improved logging for Stripe event processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->