### PR TITLE
Add error handling to Register method in AccountController for invitation validation

### DIFF
--- a/aspnet-core/src/toyiyo.todo.Web.Mvc/Controllers/AccountController.cs
+++ b/aspnet-core/src/toyiyo.todo.Web.Mvc/Controllers/AccountController.cs
@@ -374,12 +374,21 @@ namespace toyiyo.todo.Web.Controllers
         [UnitOfWork]
         public async Task<ActionResult> Register(string token)
         {
-            var invitationResult = await _userInvitationAppService.ValidateInvitationAsync(token);
-
-            return RegisterView(new RegisterViewModel
+            try
             {
-                EmailAddress = invitationResult.Email
-            });
+                var invitationResult = await _userInvitationAppService.ValidateInvitationAsync(token);
+
+                return RegisterView(new RegisterViewModel
+                {
+                    EmailAddress = invitationResult.Email
+                });
+            }
+            catch (Exception ex)
+            {
+                ViewBag.ErrorMessage = ex.Message;
+
+                return View("Register", new RegisterViewModel());
+            }
 
         }
 
@@ -494,9 +503,7 @@ namespace toyiyo.todo.Web.Controllers
                     IsEmailConfirmationRequiredForLogin = isEmailConfirmationRequiredForLogin
                 });
             }
-
-
-            catch (UserFriendlyException ex)
+            catch (Exception ex)
             {
                 ViewBag.ErrorMessage = ex.Message;
                 ViewBag.Token = token;


### PR DESCRIPTION
This pull request includes changes to improve error handling in the `Register` method of the `AccountController` class. The most important changes include adding a try-catch block to handle exceptions and ensuring that error messages are displayed to the user.

Error handling improvements:

* [`aspnet-core/src/toyiyo.todo.Web.Mvc/Controllers/AccountController.cs`](diffhunk://#diff-950ba703294539d6a7c18d5d5ae7b197efa3c1c43682ae7dbb6e924468080b5cR376-R391): Added a try-catch block in the `Register` method to catch general exceptions and display error messages using `ViewBag.ErrorMessage`.
* [`aspnet-core/src/toyiyo.todo.Web.Mvc/Controllers/AccountController.cs`](diffhunk://#diff-950ba703294539d6a7c18d5d5ae7b197efa3c1c43682ae7dbb6e924468080b5cL497-R506): Modified the existing catch block in the `Register` method to catch general exceptions instead of `UserFriendlyException` and display error messages using `ViewBag.ErrorMessage`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling for the registration process, providing better user feedback on errors.
	- Improved population of the registration model with email addresses from invitations.

- **Bug Fixes**
	- Adjusted the login method to ensure proper normalization of return URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->