### PR TITLE
Fix code scanning alert no. 4: Log entries created from user input

### DIFF
--- a/aspnet-core/src/toyiyo.todo.Web.Mvc/Controllers/AccountController.cs
+++ b/aspnet-core/src/toyiyo.todo.Web.Mvc/Controllers/AccountController.cs
@@ -559,7 +559,7 @@ namespace toyiyo.todo.Web.Controllers
 
             if (remoteError != null)
             {
-                Logger.Error("Remote Error in ExternalLoginCallback: " + remoteError);
+                Logger.Error("Remote Error in ExternalLoginCallback: " + remoteError.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", ""));
                 throw new UserFriendlyException(L("CouldNotCompleteLoginOperation"));
             }
 


### PR DESCRIPTION
Fixes [https://github.com/toyiyo/todo/security/code-scanning/4](https://github.com/toyiyo/todo/security/code-scanning/4)

To fix the problem, we need to sanitize the `remoteError` variable before logging it. Since the log entries are plain text, we should remove any newline characters from the `remoteError` string to prevent log forging. This can be done using the `String.Replace` method to replace newline characters with an empty string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error logging during external login by sanitizing error messages to enhance readability.
  
- **Refactor**
	- Updated the error handling mechanism in the `ExternalLoginCallback` method without altering overall functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->