### PR TITLE
Enhance notification preference tests with additional scenarios and v…

### DIFF
--- a/aspnet-core/test/toyiyo.todo.Tests/Notifications/NotificationPreferenceAppService_Tests.cs
+++ b/aspnet-core/test/toyiyo.todo.Tests/Notifications/NotificationPreferenceAppService_Tests.cs
@@ -1,4 +1,7 @@
+using System.Linq;
 using System.Threading.Tasks;
+using Abp.Runtime.Session;
+using Microsoft.EntityFrameworkCore;
 using Shouldly;
 using toyiyo.todo.Notifications;
 using toyiyo.todo.Notifications.Dto;
@@ -13,28 +16,32 @@ namespace toyiyo.todo.Tests.Notifications
         public NotificationPreferenceAppService_Tests()
         {
             _notificationPreferenceAppService = Resolve<INotificationPreferenceAppService>();
+            LoginAsDefaultTenantAdmin();
         }
 
         [Fact]
-        public async Task Should_Get_User_Preferences()
+        public async Task Should_Initialize_Default_Preferences()
         {
-            // Arrange
-            LoginAsDefaultTenantAdmin();
-
             // Act
-            var preferences = await _notificationPreferenceAppService.GetUserPreferences();
+            var result = await _notificationPreferenceAppService.GetUserPreferences();
 
             // Assert
-            preferences.ShouldNotBeNull();
-            preferences.Items.ShouldNotBeEmpty();
-            preferences.Items.ShouldContain(p => p.NotificationType == NotificationType.UserMention);
+            result.TotalCount.ShouldBeGreaterThan(0);
+            result.Items.ShouldContain(p => p.NotificationType == NotificationType.UserMention 
+                && p.Channel == NotificationChannel.Email);
+            result.Items.ShouldContain(p => p.NotificationType == NotificationType.UserMention 
+                && p.Channel == NotificationChannel.InApp);
+
+            // Verify all items have display names
+            result.Items.All(p => !string.IsNullOrEmpty(p.DisplayName)).ShouldBeTrue();
+            result.Items.All(p => !string.IsNullOrEmpty(p.ChannelDisplayName)).ShouldBeTrue();
         }
 
         [Fact]
-        public async Task Should_Update_User_Preference()
+        public async Task Should_Update_Existing_Preference()
         {
             // Arrange
-            LoginAsDefaultTenantAdmin();
+            await _notificationPreferenceAppService.GetUserPreferences(); // Initialize preferences
             var input = new UpdateNotificationPreferenceInput
             {
                 NotificationType = NotificationType.UserMention,
@@ -48,6 +55,8 @@ namespace toyiyo.todo.Tests.Notifications
             // Assert
             result.ShouldNotBeNull();
             result.IsEnabled.ShouldBeFalse();
+            result.NotificationType.ShouldBe(input.NotificationType);
+            result.Channel.ShouldBe(input.Channel);
 
             // Verify the change persisted
             var preferences = await _notificationPreferenceAppService.GetUserPreferences();
@@ -56,6 +65,76 @@ namespace toyiyo.todo.Tests.Notifications
                 p.Channel == input.Channel && 
                 p.IsEnabled == input.IsEnabled
             );
+        }
+
+        [Fact]
+        public async Task Should_Create_New_Preference_If_Not_Exists()
+        {
+            // Arrange
+            var input = new UpdateNotificationPreferenceInput
+            {
+                NotificationType = NotificationType.UserMention,
+                Channel = NotificationChannel.InApp,
+                IsEnabled = true
+            };
+
+            // Act
+            var result = await _notificationPreferenceAppService.UpdatePreference(input);
+
+            // Assert
+            result.ShouldNotBeNull();
+            result.IsEnabled.ShouldBeTrue();
+            result.NotificationType.ShouldBe(input.NotificationType);
+            result.Channel.ShouldBe(input.Channel);
+        }
+
+        [Fact]
+        public async Task Should_Return_Cached_Preferences_On_Subsequent_Calls()
+        {
+            // Act
+            var firstResult = await _notificationPreferenceAppService.GetUserPreferences();
+            var secondResult = await _notificationPreferenceAppService.GetUserPreferences();
+
+            // Assert
+            firstResult.TotalCount.ShouldBe(secondResult.TotalCount);
+            firstResult.Items.Count.ShouldBe(secondResult.Items.Count);
+        }
+
+        [Fact]
+        public async Task Should_Require_Authentication()
+        {
+            // Arrange
+            var abpSession = Resolve<IAbpSession>();
+            abpSession.UserId = null;
+
+            // Act & Assert
+            await Should.ThrowAsync<Abp.Authorization.AbpAuthorizationException>(async () =>
+                await _notificationPreferenceAppService.GetUserPreferences()
+            );
+        }
+
+        [Fact]
+        public async Task Should_Toggle_Multiple_Times()
+        {
+            // Arrange
+            var input = new UpdateNotificationPreferenceInput
+            {
+                NotificationType = NotificationType.UserMention,
+                Channel = NotificationChannel.Email,
+                IsEnabled = false
+            };
+
+            // Act & Assert
+            var result1 = await _notificationPreferenceAppService.UpdatePreference(input);
+            result1.IsEnabled.ShouldBeFalse();
+
+            input.IsEnabled = true;
+            var result2 = await _notificationPreferenceAppService.UpdatePreference(input);
+            result2.IsEnabled.ShouldBeTrue();
+
+            input.IsEnabled = false;
+            var result3 = await _notificationPreferenceAppService.UpdatePreference(input);
+            result3.IsEnabled.ShouldBeFalse();
         }
     }
 }

--- a/aspnet-core/test/toyiyo.todo.Tests/Notifications/NotificationPreference_Tests.cs
+++ b/aspnet-core/test/toyiyo.todo.Tests/Notifications/NotificationPreference_Tests.cs
@@ -30,21 +30,39 @@ namespace toyiyo.todo.Tests.Notifications
         public void Should_Toggle_Preference()
         {
             // Arrange
+            var userId = 1;
             var preference = NotificationPreference.Create(1, NotificationType.UserMention, NotificationChannel.Email);
             
-            // Act
-            preference.Toggle(false, 1);
-
-            // Assert
+            // Act & Assert
+            preference.Toggle(false, userId);
             preference.IsEnabled.ShouldBeFalse();
+            preference.LastModifierUserId.ShouldBe(userId);
+
+            preference.Toggle(true, userId);
+            preference.IsEnabled.ShouldBeTrue();
+            preference.LastModifierUserId.ShouldBe(userId);
         }
 
-        [Fact]
-        public void Should_Not_Create_With_Invalid_UserId()
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-1)]
+        public void Should_Not_Create_With_Invalid_UserId(int invalidUserId)
         {
             // Act & Assert
             Should.Throw<ArgumentException>(() =>
-                NotificationPreference.Create(0, NotificationType.UserMention, NotificationChannel.Email)
+                NotificationPreference.Create(invalidUserId, NotificationType.UserMention, NotificationChannel.Email)
+            );
+        }
+
+        [Fact]
+        public void Should_Not_Toggle_With_Invalid_UserId()
+        {
+            // Arrange
+            var preference = NotificationPreference.Create(1, NotificationType.UserMention, NotificationChannel.Email);
+
+            // Act & Assert
+            Should.Throw<ArgumentException>(() =>
+                preference.Toggle(false, 0)
             );
         }
     }


### PR DESCRIPTION
This pull request includes several changes to the `NotificationPreferenceAppService_Tests` and `NotificationPreference_Tests` classes to enhance the testing of notification preferences in the application. The changes include new tests, modifications to existing tests, and improvements to assertions.

### Enhancements to `NotificationPreferenceAppService_Tests`:

* Added new tests to cover additional scenarios such as creating new preferences, returning cached preferences, requiring authentication, and toggling preferences multiple times.
* Modified the `Should_Get_User_Preferences` test to `Should_Initialize_Default_Preferences` and improved assertions to verify all items have display names and channel display names.
* Updated the `Should_Update_User_Preference` test to `Should_Update_Existing_Preference` and added assertions to check the notification type and channel.

### Improvements to `NotificationPreference_Tests`:

* Added a new test to ensure that preferences cannot be created with invalid user IDs using `[Theory]` and `[InlineData]`.
* Enhanced the `Should_Toggle_Preference` test to include assertions for `LastModifierUserId` and added a new test to ensure toggling preferences with invalid user IDs throws an exception.

### Codebase improvements:

* Added necessary `using` directives for `System.Linq`, `Abp.Runtime.Session`, and `Microsoft.EntityFrameworkCore` to the `NotificationPreferenceAppService_Tests` class.…alidations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded coverage confirms robust handling of notification preferences, including proper initialization, updating, caching, and toggling.
  - Enhanced validations ensure that invalid input is caught and that access requires proper authentication.
  - Multiple usage scenarios are now verified, helping maintain consistent behavior for notification settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->