### PR TITLE
Update Hangfire configuration for ToyiyoDb

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 6.0.x
     - name: Restore dependencies
@@ -29,7 +29,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 6.0.x
     - name: Test with coverage
@@ -56,7 +56,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 6.0.x
     - name: Set up JDK 17
@@ -79,14 +79,14 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore aspnet-core/toyiyo.todo.sln
     - name: Cache SonarCloud packages
-      uses: actions/cache@v1
+      uses: actions/cache@v4
       with:
         path: ~\sonar\cache
         key: ${{ runner.os }}-sonar
         restore-keys: ${{ runner.os }}-sonar
     - name: Cache SonarCloud scanner
       id: cache-sonar-scanner
-      uses: actions/cache@v1
+      uses: actions/cache@v4
       with:
         path: .\.sonar\scanner
         key: ${{ runner.os }}-sonar-scanner

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -79,14 +79,14 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore aspnet-core/toyiyo.todo.sln
     - name: Cache SonarCloud packages
-      uses: actions/cache@v2
+      uses: actions/cache@v1
       with:
         path: ~\sonar\cache
         key: ${{ runner.os }}-sonar
         restore-keys: ${{ runner.os }}-sonar
     - name: Cache SonarCloud scanner
       id: cache-sonar-scanner
-      uses: actions/cache@v2
+      uses: actions/cache@v1
       with:
         path: .\.sonar\scanner
         key: ${{ runner.os }}-sonar-scanner

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -69,7 +69,7 @@ jobs:
         fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
     - uses: actions/checkout@v2
     - name: Setup .NET
-      uses: actions/setup-dotnet@v2
+      uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 6.0.x
     - name: Download coverage results

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -69,7 +69,7 @@ jobs:
         fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
     - uses: actions/checkout@v2
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v2
       with:
         dotnet-version: 6.0.x
     - name: Download coverage results

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -79,14 +79,14 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore aspnet-core/toyiyo.todo.sln
     - name: Cache SonarCloud packages
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: ~\sonar\cache
         key: ${{ runner.os }}-sonar
         restore-keys: ${{ runner.os }}-sonar
     - name: Cache SonarCloud scanner
       id: cache-sonar-scanner
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: .\.sonar\scanner
         key: ${{ runner.os }}-sonar-scanner

--- a/aspnet-core/src/toyiyo.todo.Web.Mvc/Startup/Startup.cs
+++ b/aspnet-core/src/toyiyo.todo.Web.Mvc/Startup/Startup.cs
@@ -74,7 +74,7 @@ namespace toyiyo.todo.Web.Startup
                 var connectionString = Environment.GetEnvironmentVariable("ToyiyoDb");
                 if (string.IsNullOrEmpty(connectionString))
                 {
-                    throw new InvalidOperationException("NEON_DB connection string is not configured");
+                    throw new InvalidOperationException("ToyiyoDb connection string is not configured");
                 }
 
                 config.UsePostgreSqlStorage(connectionString, new PostgreSqlStorageOptions

--- a/aspnet-core/src/toyiyo.todo.Web.Mvc/Startup/Startup.cs
+++ b/aspnet-core/src/toyiyo.todo.Web.Mvc/Startup/Startup.cs
@@ -71,7 +71,7 @@ namespace toyiyo.todo.Web.Startup
             // Configure Hangfire with retry attempts
             services.AddHangfire(config =>
             {
-                var connectionString = Environment.GetEnvironmentVariable("NEON_DB");
+                var connectionString = Environment.GetEnvironmentVariable("ToyiyoDb");
                 if (string.IsNullOrEmpty(connectionString))
                 {
                     throw new InvalidOperationException("NEON_DB connection string is not configured");
@@ -79,7 +79,7 @@ namespace toyiyo.todo.Web.Startup
 
                 config.UsePostgreSqlStorage(connectionString, new PostgreSqlStorageOptions
                 {
-                    SchemaName = "hangfire",
+                    SchemaName = "public",
                     PrepareSchemaIfNecessary = true // We handle this manually above
                 })
                 .UseFilter(new AutomaticRetryAttribute { Attempts = 3 });


### PR DESCRIPTION
Change the Hangfire configuration to use the ToyiyoDb connection string and update the schema name to public.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated background job processing configuration with refined connection settings and storage parameters, contributing to enhanced system reliability.
	- Updated the version of the .NET setup action in the workflow for improved build and test processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->